### PR TITLE
feat: add visual verification protocol via browser-use MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on Keep a Changelog, and versions are intended to map to Git
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-03-29
+
+### Added
+
+- Visual Verification Protocol (`references/visual.md`): browser-use MCP によるライブブラウザ視覚検証の共有手順（PROC:ENTRY / PROC:FOLD / PROC:RESPONSIVE / PROC:STATES）。
+- `ma-review` Workflow Step 0: 5軸監査の前に PROC:ENTRY で視覚基準を確立する。
+- `ma-review` レポートテンプレートに Visual Reference セクションを追加。
+- `ma-flow` Process Step 3: PROC:FOLD による視覚的読み経路の確認。
+- `ma-legibility` Process Step 3: PROC:STATES による focus / contrast / error 状態の視覚検証。
+- `ma` Workflow Step 5: PROC:ENTRY による実装方針の視覚的根拠確保。
+- `ma-mapping` Process Step 2: PROC:ENTRY による囲みとグループの視覚的帰属確認。
+- `ma-system` Process Step 2: PROC:RESPONSIVE による breakpoint 間の token 逸脱確認。
+- `ma-reduction` Process Step 1: PROC:FOLD による below-fold 情報密度の確認。
+
+### Changed
+
+- `ma-review` 実行ルール: 「コードから推測される問題」と「画面で確認された問題」の区別を必須化。
+
 ## [1.2.0] - 2026-03-23
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -669,7 +669,7 @@ a:focus-visible, button:focus-visible {
       <button class="copy-btn" id="copy-btn" type="button">Copy</button>
     </div>
     <p class="install-note">
-      v1.2.0 · MIT ·
+      v1.3.0 · MIT ·
       <a href="https://github.com/yyyyyyy0/ma-skills/releases">
         <span class="t-ja">リリース一覧</span>
         <span class="t-en">Releases</span>

--- a/skills/ma-flow/SKILL.md
+++ b/skills/ma-flow/SKILL.md
@@ -9,7 +9,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - ui-flow
     - reading-order
@@ -67,9 +67,15 @@ metadata:
 
 1. 最初に目が行く要素を特定する
 2. 自然な読み経路をトレースする
-3. ユーザーが理解すべき論理順序を並べる
-4. 視覚順序と論理順序のズレを洗い出す
-5. 余白・ウェイト・位置・サイズで修正案を出す
+3. 視覚的な読み経路を実際のレンダリングで確認する
+   URL がある場合: `ma/references/visual.md` の PROC:FOLD を実行する。
+   - viewport screenshot で最初の焦点を記録する
+   - full-page screenshot でスクロール深度と CTA 埋もれを確認する
+   - 視覚的順序と Step 2 でトレースした経路との差分を記録する
+   URL がない場合はこのステップをスキップし、「視覚検証スキップ — ライブ URL なし」と記録する。
+4. ユーザーが理解すべき論理順序を並べる
+5. 視覚順序と論理順序のズレを洗い出す
+6. 余白・ウェイト・位置・サイズで修正案を出す
 
 ## Constraints
 

--- a/skills/ma-legibility/SKILL.md
+++ b/skills/ma-legibility/SKILL.md
@@ -9,7 +9,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - accessibility
     - readability
@@ -67,6 +67,11 @@ metadata:
 1. すべての文字列を初見のつもりで読む
 2. 文脈依存の文言に印を付ける
 3. コントラスト不足と focus 不可視を確認する
+   URL がある場合: `ma/references/visual.md` の PROC:STATES を実行する。
+   - 各インタラクティブ要素の focus 状態をスクリーンショットで記録する
+   - disabled / error 状態の要素があればスクリーンショットを取得する
+   - viewport screenshot で上位テキストのコントラストを観測する
+   URL がない場合はコードから推測し、「視覚検証スキップ — ライブ URL なし」と記録する。
 4. エラー、空、ローディングの文言具体性を点検する
 5. キーボードだけで操作して破綻点を探す
 

--- a/skills/ma-mapping/SKILL.md
+++ b/skills/ma-mapping/SKILL.md
@@ -9,7 +9,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - mapping
     - action-scope
@@ -62,6 +62,9 @@ metadata:
 
 1. 各インタラクティブ要素に「これは何に作用するか」と問う
 2. 位置と囲みだけで答えられるか確認する
+   URL がある場合: `ma/references/visual.md` の PROC:ENTRY を実行し、
+   囲みとグループの視覚的帰属をスクリーンショットで確認する。
+   URL がない場合はコードから推測し、「視覚検証スキップ — ライブ URL なし」と記録する。
 3. 足りなければ、ラベルの具体性を点検する
 4. 単一対象、複数対象、一括対象を分けて評価する
 

--- a/skills/ma-reduction/SKILL.md
+++ b/skills/ma-reduction/SKILL.md
@@ -9,7 +9,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - simplification
     - declutter
@@ -64,6 +64,9 @@ metadata:
 ## Process
 
 1. 各要素について「消すと何を失うか」を問う
+   URL がある場合: `ma/references/visual.md` の PROC:FOLD を実行し、
+   below-fold に押し込まれた項目と初期表示の情報密度を記録する。
+   URL がない場合はコードから推測し、「視覚検証スキップ — ライブ URL なし」と記録する。
 2. 失うものがない、または遅らせられるなら削除または延期する
 3. 必要な複雑さと偶発的な複雑さを分ける
 4. 最後に、本質がまだ十分見えているか確認する

--- a/skills/ma-review/SKILL.md
+++ b/skills/ma-review/SKILL.md
@@ -9,7 +9,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - ui-review
     - audit
@@ -37,6 +37,10 @@ metadata:
 
 ## Workflow
 
+0. 視覚基準を確立する
+   URL または localhost アドレスが提供されている場合: `ma/references/visual.md` の PROC:ENTRY を実行する。
+   スクリーンショットと観測メモは監査の証拠として各サブスキルの所見と照合する。
+   URL が提供されていない場合は「視覚検証スキップ — ライブ URL なし」と記録して Step 1 へ進む。
 1. `ma-system` を実行する
 2. `ma-legibility` を実行する
 3. `ma-mapping` を実行する
@@ -53,6 +57,8 @@ metadata:
 - 所見は必ず、どの原則に違反しているかを書く
 - Priority actions は、抽象論ではなく実行可能な修正案にする
 - 測定や実験が意味判断の代替として使われていないかを確認し、使われている場合は既存5軸の違反として記録する
+- 視覚検証を実行した場合、所見はスクリーンショットの観測に根拠を持たせること
+- 「コードから推測される問題」と「画面で確認された問題」は区別して記録すること
 
 ## Protocol
 

--- a/skills/ma-review/assets/report-template.md
+++ b/skills/ma-review/assets/report-template.md
@@ -1,5 +1,11 @@
 # ma-review — [コンポーネントまたは画面名]
 
+## Visual Reference
+
+[ma-review Step 0 PROC:ENTRY の観測メモ。
+各軸のサブスキルが実行した追加の PROC（PROC:FOLD, PROC:STATES 等）は各軸の所見内にインライン記録する。
+URL なしの場合は「視覚検証スキップ — ライブ URL なし」と記録する。]
+
 ---
 
 ## 1. System (ma-system)

--- a/skills/ma-system/SKILL.md
+++ b/skills/ma-system/SKILL.md
@@ -9,7 +9,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - design-system
     - consistency
@@ -62,6 +62,9 @@ metadata:
 
 1. 既存 UI から暗黙の正規値を抽出する
 2. 逸脱点を見つける
+   URL がある場合: `ma/references/visual.md` の PROC:RESPONSIVE を実行し、
+   breakpoint ごとの spacing scale と token 逸脱をスクリーンショットで確認する。
+   URL がない場合はコードから推測し、「視覚検証スキップ — ライブ URL なし」と記録する。
 3. 新しい値を増やさず、既存正規値へ統合する
 4. 状態表現と semantic role の対応を確認する
 

--- a/skills/ma/SKILL.md
+++ b/skills/ma/SKILL.md
@@ -13,7 +13,7 @@ description: >
 license: MIT
 metadata:
   author: yyyyyyy0
-  version: 1.2.0
+  version: 1.3.0
   tags:
     - ui-design
     - implementation
@@ -71,6 +71,10 @@ UIデザインの根拠となる2つの原則は、情報の明瞭性と目的�
    - 状態管理の方針（どの状態をどこで持つか）
    - スタイリングの方針（トークン利用、レスポンシブ戦略）
    - 段階的開示の実装手段（条件付きレンダリング、タブ、アコーディオン等）
+   - 視覚検証が可能な場合（URL が提供されている場合）:
+     `references/visual.md` の PROC:ENTRY を実行し、
+     above-fold の状態と CTA 到達性を実装方針の根拠として記録する。
+     URL がない場合は「視覚検証スキップ — ライブ URL なし」と明記する。
 6. 完成物レビューが必要なら `ma-review` に渡す
 
 詳細ルール:

--- a/skills/ma/references/visual.md
+++ b/skills/ma/references/visual.md
@@ -1,0 +1,101 @@
+# Visual Verification Protocol
+
+ライブブラウザで実際の描画結果を確認し、コードや説明文だけでは検出できない
+視覚的問題を発見するための共有手順。
+
+## 前提
+
+- URL または localhost アドレスが提供されていること
+- 提供されていない場合は「視覚検証スキップ — ライブ URL なし」と記録し、このプロトコルを飛ばす
+- browser-use MCP ツールを使用する
+
+## 手順
+
+### PROC:ENTRY — 基本撮影
+
+最小限の視覚的証拠を確保する。すべてのスキルの基本手順。
+
+1. `browser_navigate` で対象 URL へ遷移する
+2. `browser_screenshot` で viewport を撮影する（above-fold の第一印象）
+3. `browser_screenshot` を `full_page: true` で実行し、ページ全体を撮影する
+4. 観測メモを即座に記録する（後回しにしない）
+5. 完了後 `browser_close_session` でセッションを閉じる
+
+### PROC:FOLD — スクロール検証
+
+below-fold に埋もれた CTA や情報の密度を確認する。
+
+1. `browser_navigate` で対象 URL へ遷移する
+2. `browser_screenshot` で viewport を撮影する（above-fold の第一印象）
+3. `browser_scroll` でページ下部まで移動する
+4. `browser_screenshot` でスクロール後の状態を撮影する
+5. above-fold と below-fold の情報密度差を記録する
+6. 主要 CTA がスクロールなしで到達可能かを記録する
+7. `browser_screenshot` を `full_page: true` で実行する
+8. 観測メモを記録する
+9. `browser_close_session` でセッションを閉じる
+
+### PROC:RESPONSIVE — レスポンシブ検証
+
+ブレイクポイント間のレイアウト崩壊と token 逸脱を確認する。
+
+3つのブレイクポイントで撮影する:
+
+| ブレイクポイント | 幅 | 代表デバイス |
+|---|---|---|
+| mobile | 375px | iPhone SE / 標準スマートフォン |
+| tablet | 768px | iPad mini / 標準タブレット |
+| desktop | 1280px | 標準ノート PC |
+
+各ブレイクポイントで:
+1. `browser_navigate` で対象 URL へ遷移する
+2. `browser_get_state` でページ状態を取得する
+3. `browser_screenshot` で viewport を撮影する
+4. 前のブレイクポイントとの差分を記録する（レイアウト崩壊、要素の消失、spacing scale の変化）
+
+viewport 幅の変更方法はブラウザ環境に依存する。
+DevTools のデバイスエミュレーション、`browser_navigate` の device パラメータ、
+またはブラウザウィンドウのリサイズを使うこと。
+使用可能な手段がない場合は desktop 幅のみで撮影し、
+「レスポンシブ検証は desktop のみ — viewport リサイズ手段なし」と記録する。
+
+最後に `browser_close_session` でセッションを閉じる。
+
+### PROC:STATES — インタラクティブ状態検証
+
+focus、hover、error、disabled など、静的コードからは見えない状態を確認する。
+
+1. `browser_navigate` で対象 URL へ遷移する
+2. 監査対象のインタラクティブ要素ごとに:
+   a. `browser_click` で要素をアクティブにする
+   b. `browser_screenshot` で状態を撮影する
+   c. 対象要素名と確認した状態を記録する
+3. error 状態がある場合はフォームに不正値を入力して `browser_screenshot` する
+4. 観測メモを記録する
+5. `browser_close_session` でセッションを閉じる
+
+## 観測メモのフォーマット
+
+各撮影後に以下を即座に記録する。撮影を全部終えてからまとめて書くのではなく、
+撮影のたびに書くこと。
+
+```
+Visual observation [手順名] @ [URL] [ブレイクポイント（該当時）]
+- 最初の焦点: [目が最初に行く要素]
+- above-fold CTA 可視: yes / no / partially
+- コントラスト問題: [具体的要素 または "none observed"]
+- レイアウト健全性: intact / broken at [要素]
+- スキル固有の注記: [当該スキルの監査ドメインに関連する観測]
+```
+
+## 手順の選択ガイド
+
+| スキル | 推奨手順 | 理由 |
+|---|---|---|
+| ma | PROC:ENTRY | 実装方針の視覚的根拠を確保 |
+| ma-review | PROC:ENTRY | 5軸共通の視覚基準を確立 |
+| ma-flow | PROC:FOLD | 視線の流れとスクロール下の CTA を確認 |
+| ma-legibility | PROC:STATES | focus ring・コントラスト・error 状態を確認 |
+| ma-mapping | PROC:ENTRY | 囲みとグループの視覚的帰属を確認 |
+| ma-system | PROC:RESPONSIVE | breakpoint 間の token 逸脱を確認 |
+| ma-reduction | PROC:FOLD | below-fold の情報密度と初期表示を確認 |

--- a/skills/ma/references/visual.md
+++ b/skills/ma/references/visual.md
@@ -67,9 +67,10 @@ focus、hover、error、disabled など、静的コードからは見えない�
 
 1. `browser_navigate` で対象 URL へ遷移する
 2. 監査対象のインタラクティブ要素ごとに:
-   a. `browser_click` で要素をアクティブにする
-   b. `browser_screenshot` で状態を撮影する
-   c. 対象要素名と確認した状態を記録する
+   a. `browser_click` で要素をアクティブにし、`browser_screenshot` で状態を撮影する
+   b. キーボードフォーカスの確認: Tab キーで要素へ移動し、`browser_screenshot` で `:focus-visible` の状態を撮影する。
+      ポインタクリックでは `:focus-visible` が発火しないブラウザがあるため、キーボード操作での確認が必要。
+   c. 対象要素名と確認した状態（click / focus-visible / hover）を記録する
 3. error 状態がある場合はフォームに不正値を入力して `browser_screenshot` する
 4. 観測メモを記録する
 5. `browser_close_session` でセッションを閉じる


### PR DESCRIPTION
## Summary

- browser-use MCP によるライブブラウザ視覚検証プロトコル (`references/visual.md`) を新規追加
- 4つの手順（PROC:ENTRY / FOLD / RESPONSIVE / STATES）を定義し、全7スキルのワークフローに統合
- URL がない場合は明示的スキップ（強制しない）

## Changes

| スキル | 変更 | 手順 |
|---|---|---|
| `ma` | Step 5 にサブステップ追加 | PROC:ENTRY |
| `ma-review` | Step 0 追加 + 実行ルール + テンプレート更新 | PROC:ENTRY |
| `ma-flow` | Step 3 挿入（以降繰り下げ） | PROC:FOLD |
| `ma-legibility` | Step 3 拡張 | PROC:STATES |
| `ma-mapping` | Step 2 拡張 | PROC:ENTRY |
| `ma-system` | Step 2 拡張 | PROC:RESPONSIVE |
| `ma-reduction` | Step 1 拡張 | PROC:FOLD |

## Test plan

- [ ] `ma-review` を localhost URL 付きで実行し、Visual Reference セクションにスクリーンショット観測メモが記録されることを確認
- [ ] URL なしで `ma-review` を実行し、「視覚検証スキップ — ライブ URL なし」が記録されることを確認
- [ ] `ma-flow` を URL 付きで実行し、Step 3 で PROC:FOLD が実行されることを確認
- [ ] `ma-legibility` を URL 付きで実行し、PROC:STATES で focus 状態のスクリーンショットが撮影されることを確認